### PR TITLE
Fix `requires-python` metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ceresdb-client"
 version = "0.1.0"
 description = "The python client for ceresdb."
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 license = { file = "LICENSE" }
 authors = [
     { name = "CeresDB Authors", email = "ceresdbservice@gmail.com" }


### PR DESCRIPTION
pyo3 0.16 only supports Python 3.7+.