### PR TITLE
docs: use absolute path for example link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The python client for [CeresDB](https://github.com/CeresDB/ceresdb).
 - [x] Query
 - [x] Write
 
-An [example](examples/read_write.py) is provided to show how to access CeresDB.
+An [example](https://github.com/CeresDB/ceresdb-client-py/blob/main/examples/read_write.py) is provided to show how to access CeresDB.
 
 ## Contributing
 Any contribution is welcome!


### PR DESCRIPTION
The example link now is a relative path which leads to confuse when it is rendered on the [pypi ceresdb-client page](https://pypi.org/project/ceresdb-client/0.1.0/).

And this PR change the link of it to absolute path so that the example file can be opened everywhere.