### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceresdb-client-py"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
 edition = "2021"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ceresdb-client"
-version = "0.1.0"
+version = "0.1.1"
 description = "The python client for ceresdb."
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
After the deletion of version 0.1.0 in pypi, the version 0.1.0 can be used any more so we have to bump the version to 0.1.1.