### PR TITLE
adapt to new version rust client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -152,12 +152,14 @@ dependencies = [
 [[package]]
 name = "ceresdb-client-rs"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/ceresdb-client-rs.git?rev=d71ac1f024f6204d86d445cd1bcddf170116b9bf#d71ac1f024f6204d86d445cd1bcddf170116b9bf"
+source = "git+https://github.com/CeresDB/ceresdb-client-rs.git?rev=dc3f84a19a941059ab9022b4f8376121551114dc#dc3f84a19a941059ab9022b4f8376121551114dc"
 dependencies = [
  "async-trait",
  "avro-rs",
  "ceresdbproto",
  "common_types",
+ "dashmap",
+ "futures",
  "grpcio",
 ]
 
@@ -253,6 +255,18 @@ checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -489,6 +503,12 @@ dependencies = [
  "pkg-config",
  "walkdir",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1", features = ["sync"] }
 
 [dependencies.ceresdb-client-rs]
 git = "https://github.com/CeresDB/ceresdb-client-rs.git"
-rev = "d71ac1f024f6204d86d445cd1bcddf170116b9bf"
+rev = "dc3f84a19a941059ab9022b4f8376121551114dc"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/read_write.py
+++ b/examples/read_write.py
@@ -1,7 +1,7 @@
 # Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 import datetime
-from ceresdb_client import Client, RpcContext, PointBuilder, ValueBuilder, WriteRequest, QueryRequest
+from ceresdb_client import Builder, RpcContext, PointBuilder, ValueBuilder, WriteRequest, QueryRequest, Mode
 import asyncio
 
 
@@ -63,7 +63,7 @@ def process_write_resp(resp):
 
 
 if __name__ == "__main__":
-    client = Client("127.0.0.1:8831")
+    client = Builder("127.0.0.1:8831", Mode.Standalone).build()
     ctx = RpcContext("public", "")
 
     print("------------------------------------------------------------------")

--- a/src/model.rs
+++ b/src/model.rs
@@ -5,10 +5,10 @@
 use std::sync::Arc;
 
 use ceresdb_client_rs::{
-    is_reserved_column_name, model as rust_model,
+    model as rust_model,
     model::{
         value::{TimestampMs, Value as RustValue},
-        write::{WriteRequestBuilder, WriteResult},
+        write::{is_reserved_column_name, WriteRequestBuilder, WriteResponse as RustWriteResponse},
         Datum, QueryResponse as RustQueryResponse,
     },
 };
@@ -450,20 +450,16 @@ impl From<WriteRequest> for rust_model::write::WriteRequest {
 
 #[pyclass]
 pub struct WriteResponse {
-    pub write_result: Arc<WriteResult>,
+    pub raw_resp: Arc<RustWriteResponse>,
 }
 
 #[pymethods]
 impl WriteResponse {
     pub fn get_success(&self) -> u32 {
-        self.write_result.success
+        self.raw_resp.success
     }
 
     pub fn get_failed(&self) -> u32 {
-        self.write_result.failed
-    }
-
-    pub fn get_metrics(&self) -> Vec<String> {
-        self.write_result.metrics.clone()
+        self.raw_resp.failed
     }
 }


### PR DESCRIPTION
# Rationale for this change
 
Now, the rust client can only be used for ceresdb of standalone mode. We should modify it for serving ceresdb of cluster mode.

# What changes are included in this PR?

+ Update rust client dependency.
+ Update python client's correspoding part.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

Users can now use client to access ceresdb of cluster mode.

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test


CI itself.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
