### PR TITLE
chore: add timeout in RpcContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 name = "ceresdb-client-rs"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/ceresdb-client-rs.git?rev=a9d9190f4f7b55171ea2ad142fb41dc9909c19c5#a9d9190f4f7b55171ea2ad142fb41dc9909c19c5"
+source = "git+https://github.com/CeresDB/ceresdb-client-rs.git?rev=f41c4006789220ef88c8721c400d8cf060fe1615#f41c4006789220ef88c8721c400d8cf060fe1615"
 dependencies = [
  "async-trait",
  "avro-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1", features = ["sync"] }
 
 [dependencies.ceresdb-client-rs]
 git = "https://github.com/CeresDB/ceresdb-client-rs.git"
-rev = "a9d9190f4f7b55171ea2ad142fb41dc9909c19c5"
+rev = "f41c4006789220ef88c8721c400d8cf060fe1615"
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,17 +26,20 @@ pub fn register_py_module(m: &PyModule) -> PyResult<()> {
 #[pyclass]
 #[derive(Clone, Debug)]
 pub struct RpcContext {
-    pub raw_ctx: Arc<RustRpcContext>,
+    pub raw_ctx: RustRpcContext,
 }
 
 #[pymethods]
 impl RpcContext {
     #[new]
     pub fn new(tenant: String, token: String) -> Self {
-        let raw_ctx = RustRpcContext { tenant, token };
-        Self {
-            raw_ctx: Arc::new(raw_ctx),
-        }
+        let raw_ctx = RustRpcContext::new(tenant, token);
+        Self { raw_ctx }
+    }
+
+    pub fn set_timeout_in_millis(&mut self, timeout_millis: u64) {
+        let timeout = Duration::from_millis(timeout_millis);
+        self.raw_ctx.timeout = Some(timeout);
     }
 
     pub fn __str__(&self) -> String {


### PR DESCRIPTION
After upgrade the ceresdb-client-rs core, the timeout is configurable in the RpcContext.